### PR TITLE
Fix autosizing on Microsoft Edge

### DIFF
--- a/src/components/TextareaAutosize.vue
+++ b/src/components/TextareaAutosize.vue
@@ -112,7 +112,7 @@ export default {
      * Auto resize textarea by height
      */
     resize: function () {
-      const important = this.isHeightImportant ? 'important' : undefined
+      const important = this.isHeightImportant ? 'important' : ''
 
       this.$el.style.setProperty('height', 'auto', important)
 


### PR DESCRIPTION
Autosizing is broken on Edge because of using `undefined` for priority of `setProperty`, using `''` fix it.

issue fixed: #11