### PR TITLE
Added rows 1

### DIFF
--- a/src/components/TextareaAutosize.vue
+++ b/src/components/TextareaAutosize.vue
@@ -1,5 +1,6 @@
 <template>
   <textarea
+    rows="1"
     @focus="resize"
     v-model="val"
     :style="computedStyles"


### PR DESCRIPTION
Added "rows=1" by default to textarea, because there was a problem with size of empty textarea